### PR TITLE
fix(workflows): resolve SAST NodeJS and Semgrep issues

### DIFF
--- a/.github/workflows/sast-nodejs.yml
+++ b/.github/workflows/sast-nodejs.yml
@@ -46,69 +46,47 @@ jobs:
           echo "Scanning entire project for JavaScript/Node.js security issues..."
           njsscan --sarif --output njsscan-full.sarif . || true
 
-      - name: Merge SARIF results
-        run: |
-          # Create combined SARIF file
-          python3 -c "
-          import json
-          import os
-
-          def merge_sarif_files():
-              files = ['backend-njsscan.sarif', 'njsscan-full.sarif']
-              merged = {
-                  'version': '2.1.0',
-                  'runs': []
-              }
-              
-              for file in files:
-                  if os.path.exists(file):
-                      try:
-                          with open(file, 'r') as f:
-                              data = json.load(f)
-                              if 'runs' in data:
-                                  merged['runs'].extend(data['runs'])
-                      except Exception as e:
-                          print(f'Error processing {file}: {e}')
-              
-              with open('njsscan.sarif', 'w') as f:
-                  json.dump(merged, f, indent=2)
-
-          merge_sarif_files()
-          "
-
       - name: Display scan summary
         run: |
           echo "NodeJsScan Analysis Complete"
-          if [ -f "njsscan.sarif" ]; then
-            echo "SARIF file generated successfully"
-            # Count findings
-            python3 -c "
-            import json
-            try:
-                with open('njsscan.sarif', 'r') as f:
-                    data = json.load(f)
-                    total_results = sum(len(run.get('results', [])) for run in data.get('runs', []))
-                    print(f'Total security findings: {total_results}')
-            except Exception as e:
-                print(f'Error reading SARIF: {e}')
-            "
+
+          # Check backend scan results
+          if [ -f "backend-njsscan.sarif" ]; then
+            echo "✓ Backend SARIF file generated successfully"
+            echo "  File size: $(du -h backend-njsscan.sarif | cut -f1)"
           else
-            echo "No SARIF file generated"
+            echo "✗ No backend SARIF file generated"
           fi
 
-      - name: Upload SARIF results to GitHub Security Dashboard
+          # Check full project scan results  
+          if [ -f "njsscan-full.sarif" ]; then
+            echo "✓ Full project SARIF file generated successfully"
+            echo "  File size: $(du -h njsscan-full.sarif | cut -f1)"
+          else
+            echo "✗ No full project SARIF file generated"
+          fi
+
+          echo "Both scans will be uploaded separately to comply with GitHub's SARIF policy"
+
+      - name: Upload Backend SARIF results to GitHub Security Dashboard
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: njsscan.sarif
-          category: nodejs-scan
-        if: always() && hashFiles('njsscan.sarif') != ''
+          sarif_file: backend-njsscan.sarif
+          category: nodejs-backend
+        if: always() && hashFiles('backend-njsscan.sarif') != ''
+
+      - name: Upload Full Project SARIF results to GitHub Security Dashboard
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: njsscan-full.sarif
+          category: nodejs-full
+        if: always() && hashFiles('njsscan-full.sarif') != ''
 
       - name: Upload NodeJsScan results as artifact
         uses: actions/upload-artifact@v4
         with:
           name: nodejs-security-results
           path: |
-            njsscan.sarif
             backend-njsscan.sarif
             njsscan-full.sarif
           retention-days: 30

--- a/.github/workflows/sast-semgrep.yml
+++ b/.github/workflows/sast-semgrep.yml
@@ -62,7 +62,6 @@ jobs:
             cat > semgrep.sarif << 'EOF'
           {
             "version": "2.1.0",
-            "schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
             "runs": [
               {
                 "tool": {


### PR DESCRIPTION
## Summary
Fix critical issues in SAST workflows that were preventing proper security scanning results upload.

## Issues Fixed

### NodeJS Scanner
- **Problem**: Merging multiple SARIF runs violated GitHub's new policy (July 2025)
- **Solution**: Upload backend and full scans as separate categories
- **Categories**: `nodejs-backend` and `nodejs-full`
- **Result**: Complies with GitHub's "one run per category" requirement

### Semgrep Scanner  
- **Problem**: Empty SARIF fallback included invalid 'schema' property
- **Solution**: Remove schema property from empty SARIF template
- **Result**: Passes GitHub's SARIF validation

## Changes Made
- Remove SARIF merge step from NodeJS workflow
- Add separate upload steps for backend and full project scans
- Remove schema property from Semgrep empty SARIF
- Simplify display summary to avoid Python/YAML conflicts
- Update artifact uploads to match new structure

## Expected Results
- All 3 SAST workflows should complete successfully 
- Security findings should appear in GitHub Security Dashboard
- NodeJS scanner's 4 detected vulnerabilities should be visible
- Separate categories for better organization of results

## Test Plan
- [x] Workflows trigger on PR
- [ ] NodeJS backend scan uploads successfully
- [ ] NodeJS full scan uploads successfully  
- [ ] Semgrep scan uploads successfully
- [ ] Security findings appear in dashboard